### PR TITLE
fix: deploy to docusaurus site only when changes go into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,21 +152,4 @@ jobs:
       - name: Build example for iOS
         run: |
           yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"
-  
-  deploy-docsite:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build Docusaurus website
-        run: |
-          cd docsite
-          yarn install 
-          yarn run build
-      - name: Deploy to GitHub Pages
-        if: success()
-        uses: crazy-max/ghaction-github-pages@v4
-        with:
-          target_branch: gh-pages
-          build_dir: docsite/build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/docdeploy.yml
+++ b/.github/workflows/docdeploy.yml
@@ -1,0 +1,25 @@
+name: docdeploy
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docsite/**'
+jobs:
+  deploy-docsite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docusaurus website
+        run: |
+          cd docsite
+          yarn install 
+          yarn run build
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v4
+        with:
+          target_branch: gh-pages
+          build_dir: docsite/build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Don't build/deploy docusaurus site on pull request, just on merges into main that contain changes in the docsite path.