### PR TITLE
feat: Add icons packages for android/ios and consume them in the tab bar

### DIFF
--- a/examples/objectdetection/android/app/build.gradle
+++ b/examples/objectdetection/android/app/build.gradle
@@ -117,3 +117,8 @@ dependencies {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+rootProject.ext.vectoricons = [
+    iconFontNames: [ 'Ionicons.ttf' ]
+]
+
+apply from: file("../../node_modules/react-native-vector-icons/fonts.gradle")

--- a/examples/objectdetection/ios/Podfile.lock
+++ b/examples/objectdetection/ios/Podfile.lock
@@ -1136,6 +1136,10 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
+  - RNVectorIcons (10.0.3):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
   - SocketRocket (0.6.1)
   - VisionCamera (3.9.2):
     - React
@@ -1222,6 +1226,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeMediaPipe (from `../../..`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - VisionCamera (from `../node_modules/react-native-vision-camera`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -1349,6 +1354,8 @@ EXTERNAL SOURCES:
     :path: "../../.."
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNVectorIcons:
+    :path: "../node_modules/react-native-vector-icons"
   VisionCamera:
     :path: "../node_modules/react-native-vision-camera"
   Yoga:
@@ -1421,6 +1428,7 @@ SPEC CHECKSUMS:
   ReactCommon: 2aa35648354bd4c4665b9a5084a7d37097b89c10
   ReactNativeMediaPipe: 92850eb7623b4bb0d6e8fe90c5e5781b42ccba00
   RNScreens: b6b64d956af3715adbfe84808694ae82d3fec74f
+  RNVectorIcons: 73ab573085f65a572d3b6233e68996d4707fd505
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   VisionCamera: 6c8ca7d04fc62fafccd8f8ad584e96f5303671f5
   Yoga: 805bf71192903b20fc14babe48080582fee65a80

--- a/examples/objectdetection/ios/objectdetection/Info.plist
+++ b/examples/objectdetection/ios/objectdetection/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+    <key>UIAppFonts</key>
+    <array>
+      <string>Ionicons.ttf</string>
+    </array>
 		<key>CFBundleDevelopmentRegion</key>
 		<string>en</string>
 		<key>CFBundleDisplayName</key>

--- a/examples/objectdetection/package.json
+++ b/examples/objectdetection/package.json
@@ -16,10 +16,12 @@
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.17",
     "@shopify/react-native-skia": "^1.0.5",
+    "@types/react-native-vector-icons": "^6.4.18",
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-safe-area-context": "^4.9.0",
     "react-native-screens": "^3.30.1",
+    "react-native-vector-icons": "^10.0.3",
     "react-native-vision-camera": "^3.9.2",
     "react-native-worklets-core": "^0.4.0"
   },

--- a/examples/objectdetection/src/App.tsx
+++ b/examples/objectdetection/src/App.tsx
@@ -2,16 +2,53 @@ import * as React from "react";
 import { CameraStream } from "./CameraStream";
 import { Photo } from "./Photo";
 import { Settings } from "./Settings";
-import { NavigationContainer } from "@react-navigation/native";
+import { NavigationContainer, type RouteProp } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { type RootTabParamList } from "./navigation";
+import Ionicons from "react-native-vector-icons/Ionicons";
 
 const Tab = createBottomTabNavigator<RootTabParamList>();
+
+type TabBarIconProps = {
+  focused: boolean;
+  color: string;
+  size: number;
+  route: RouteProp<RootTabParamList, keyof RootTabParamList>;
+};
+
+const RenderTabBarIcon: React.FC<TabBarIconProps> = ({
+  focused,
+  color,
+  size,
+  route,
+}) => {
+  let iconName;
+
+  if (route.name === "CameraStream") {
+    iconName = focused ? "camera" : "camera-outline";
+  } else if (route.name === "Photo") {
+    iconName = focused ? "document" : "document-outline";
+  } else {
+    // if (route.name === "Settings")
+    iconName = focused ? "cog" : "cog-outline";
+  }
+
+  return <Ionicons name={iconName} size={size} color={color} />;
+};
 
 function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator initialRouteName="CameraStream">
+      <Tab.Navigator
+        initialRouteName="CameraStream"
+        screenOptions={({ route }) => ({
+          tabBarIcon: ({ focused, color, size }) => {
+            return RenderTabBarIcon({ focused, color, size, route });
+          },
+          tabBarActiveTintColor: "tomato",
+          tabBarInactiveTintColor: "gray",
+        })}
+      >
         <Tab.Screen
           name="CameraStream"
           component={CameraStream}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5873,6 +5873,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-native-vector-icons@npm:^6.4.18":
+  version: 6.4.18
+  resolution: "@types/react-native-vector-icons@npm:6.4.18"
+  dependencies:
+    "@types/react": "*"
+    "@types/react-native": ^0.70
+  checksum: 1ef458cb5e7a37f41eb400e3153940b1b152e4df76a7c06c7a47c712dbfe46e14b9999f04dde1bd074f338f850e161c6c925174ddea33386b74f8112c940065b
+  languageName: node
+  linkType: hard
+
+"@types/react-native@npm:^0.70":
+  version: 0.70.19
+  resolution: "@types/react-native@npm:0.70.19"
+  dependencies:
+    "@types/react": "*"
+  checksum: 79b504fa56340631079e7c20ea0d9412ec14147b76d0ce189f4403936f529ef1e6fd031383afab117846c5ae039123bcf3afc948bae4432269c6780282726f71
+  languageName: node
+  linkType: hard
+
 "@types/react-router-config@npm:*, @types/react-router-config@npm:^5.0.7":
   version: 5.0.11
   resolution: "@types/react-router-config@npm:5.0.11"
@@ -15873,6 +15892,7 @@ __metadata:
     "@react-navigation/native": ^6.1.17
     "@shopify/react-native-skia": ^1.0.5
     "@types/react": ^18.2.6
+    "@types/react-native-vector-icons": ^6.4.18
     "@types/react-test-renderer": ^18.0.0
     babel-jest: ^29.6.3
     babel-plugin-module-resolver: ^5.0.0
@@ -15883,6 +15903,7 @@ __metadata:
     react-native: 0.73.6
     react-native-safe-area-context: ^4.9.0
     react-native-screens: ^3.30.1
+    react-native-vector-icons: ^10.0.3
     react-native-vision-camera: ^3.9.2
     react-native-worklets-core: ^0.4.0
     react-test-renderer: 18.2.0
@@ -17611,6 +17632,21 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: e6c9b69ec97a4e46dd335ed25312c3621546bf0959754338aabbd4a16cc9cfb259548c996d2d737ea772a7b2ce7f198ffcd2977673e74c141334ce94fa3861c6
+  languageName: node
+  linkType: hard
+
+"react-native-vector-icons@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "react-native-vector-icons@npm:10.0.3"
+  dependencies:
+    prop-types: ^15.7.2
+    yargs: ^16.1.1
+  bin:
+    fa-upgrade.sh: bin/fa-upgrade.sh
+    fa5-upgrade: bin/fa5-upgrade.sh
+    fa6-upgrade: bin/fa6-upgrade.sh
+    generate-icon: bin/generate-icon.js
+  checksum: 77f22804b0217b4b21e8f4baaee6d33d09429bf55a31e07347fb5ab0af395b0d9adc0cbc3abd46f689ccaf07b953dc909eba95213bce7e03b562801fe4fd0768
   languageName: node
   linkType: hard
 
@@ -21372,7 +21408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.2.0":
+"yargs@npm:^16.1.1, yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
This PR adds react-native-vector-icons to to the object-detection sample and uses them in the tab bar.
I've only explicitly included the ionic icon set, which is the one that the sample used and one that I have a little familiarity with, but it should be simple enough to swap that out or add others.

The main thing I'm unsure of in this PR is how I am rendering the tab bar.  The [sample](https://reactnavigation.org/docs/tab-based-navigation#customizing-the-appearance) from react-navigation was in javascript and possibly not "correct" even then since they embedded the tab bar in the settings options, which generated [linting errors](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md).

I've extracted the code into a function component and got the types all agreeing.  Several questions:
- Am I going down the right path here?
- What's a good name for this functional component?  I am not particularly happy with `RenderTabBarIcon`, but [naming is hard](https://martinfowler.com/bliki/TwoHardThings.html)
- Where is our line for extracting components to files?  Should `RenderTabBarIcon` be in its own file - my leaning would be yes, but most of the react samples I've been seeing cram a bunch of stuff into one file (and this is a sample).
- I used `React.FC` for typing since that's what @cdiddy77 suggested elsewhere, but it sounds like this is [somewhat controversial](https://github.com/facebook/create-react-app/pull/8177) in the React community.
- If we are using React.FC in general, should we explicitly type the App FC?  