### PR TITLE
feat: add a ref prop to give access to react native camera

### DIFF
--- a/examples/posedetection/src/Drawing.tsx
+++ b/examples/posedetection/src/Drawing.tsx
@@ -52,4 +52,4 @@ const COLOR_NAMES = [
   "Violet",
 ] as const;
 
-type ColorName = (typeof COLOR_NAMES)[number];
+export type ColorName = (typeof COLOR_NAMES)[number];


### PR DESCRIPTION
Thanks to Angel E -- make so `MediapipeCamera` exposes the ref of the underlying `Camera` and give access to RNVC camera functionality